### PR TITLE
Remove duplicate data source definitions

### DIFF
--- a/desc/graph/meminfo.xml
+++ b/desc/graph/meminfo.xml
@@ -49,19 +49,7 @@
 		<name>MemTotal</name>
 	</add>
 	<add>
-		<name>Buffers</name>
-	</add>
-	<add>
 		<name>Cached</name>
-	</add>
-	<add>
-		<name>MemFree</name>
-	</add>
-	<add>
-		<name>AnonPages</name>
-	</add>
-	<add>
-		<name>Mapped</name>
 	</add>
 	<add>
 		<legend>Other memory</legend>

--- a/desc/graph/meminfocommited.xml
+++ b/desc/graph/meminfocommited.xml
@@ -16,9 +16,6 @@
 		<name>SwapFree</name>
 	</add>
 	<add>
-		<name>SwapCached</name>
-	</add>
-	<add>
 		<name>AnonPages</name>
 	</add>
 	<add>


### PR DESCRIPTION
This caused errors like the following:

    ERROR - Datasource 'SwapCached' defined twice in MeminfoAnonymous, for found: DsDesc(SwapCached,[//SwapCached],"",stack,Color[0, 0, 255],"Anonymous pages both in swap and RAM",AVERAGE)
    ERROR - Datasource 'AnonPages' defined twice in MeminfoRAM, for found: DsDesc(AnonPages,[//AnonPages],"",stack,Color[0, 255, 0],"Anonymous memory",AVERAGE)
    ERROR - Datasource 'Mapped' defined twice in MeminfoRAM, for found: DsDesc(Mapped,[//Mapped],"",stack,Color[0, 255, 255],"Memory mapped files in the pagecache",AVERAGE)
    ERROR - Datasource 'Buffers' defined twice in MeminfoRAM, for found: DsDesc(Buffers,[//Buffers],"",stack,Color[255, 200, 0],"Memory in buffer cache",AVERAGE)
    ERROR - Datasource 'MemFree' defined twice in MeminfoRAM, for found: DsDesc(MemFree,[//MemFree],"",stack,Color[0, 0, 0],"Memory free",AVERAGE)
    ERROR - Datasource 'SwapCached' defined twice in MeminfoAnonymous, for found: DsDesc(SwapCached,[//SwapCached],"",stack,Color[0, 0, 255],"Anonymous pages both in swap and RAM",AVERAGE)
    ERROR - Datasource 'AnonPages' defined twice in MeminfoRAM, for found: DsDesc(AnonPages,[//AnonPages],"",stack,Color[0, 255, 0],"Anonymous memory",AVERAGE)
    ERROR - Datasource 'Mapped' defined twice in MeminfoRAM, for found: DsDesc(Mapped,[//Mapped],"",stack,Color[0, 255, 255],"Memory mapped files in the pagecache",AVERAGE)
    ERROR - Datasource 'Buffers' defined twice in MeminfoRAM, for found: DsDesc(Buffers,[//Buffers],"",stack,Color[255, 200, 0],"Memory in buffer cache",AVERAGE)
    ERROR - Datasource 'MemFree' defined twice in MeminfoRAM, for found: DsDesc(MemFree,[//MemFree],"",stack,Color[0, 0, 0],"Memory free",AVERAGE)

… and it seems to work fine without.

All duplicates were found using:

```sh
for graph in desc/graph/**/*.xml; do
  sed -n 's@.*<\(dsN\|n\)ame>\([^<]\+\)</\(dsN\|n\)ame>.*@\2@p' $graph |
    sort |
    uniq -c |
    sort -nrk1 |
    awk '$1 > 1'
done
```